### PR TITLE
Add Galaxy A7 preset (E5 mapping) and restore codec compatibility path

### DIFF
--- a/app/src/main/java/com/kooo/evcam/AppConfig.java
+++ b/app/src/main/java/com/kooo/evcam/AppConfig.java
@@ -356,6 +356,7 @@ public class AppConfig {
     
     // 车型常量
     public static final String CAR_MODEL_GALAXY_E5 = "galaxy_e5";  // 银河E5
+    public static final String CAR_MODEL_GALAXY_A7 = "galaxy_a7";  // 银河A7（沿用E5配置）
     public static final String CAR_MODEL_E5_MULTI = "galaxy_e5_multi";  // 银河E5-多按钮
     public static final String CAR_MODEL_L7 = "galaxy_l7";  // 银河L6/L7
     public static final String CAR_MODEL_L7_MULTI = "galaxy_l7_multi";  // 银河L7-多按钮
@@ -840,6 +841,7 @@ public class AppConfig {
             case CAR_MODEL_PHONE:
                 return 2;  // 手机：2摄
             case CAR_MODEL_GALAXY_E5:
+            case CAR_MODEL_GALAXY_A7:
             case CAR_MODEL_E5_MULTI:
             case CAR_MODEL_L7:
             case CAR_MODEL_L7_MULTI:

--- a/app/src/main/java/com/kooo/evcam/MainActivity.java
+++ b/app/src/main/java/com/kooo/evcam/MainActivity.java
@@ -976,6 +976,13 @@ public class MainActivity extends AppCompatActivity {
             requiredTextureCount = 4;
             AppLog.d(TAG, "使用26款星舰7配置：横屏4摄像头布局");
         }
+        // 银河A7：横屏四摄像头布局（沿用银河E5）
+        else if (AppConfig.CAR_MODEL_GALAXY_A7.equals(carModel)) {
+            layoutId = R.layout.activity_main;
+            configuredCameraCount = 4;
+            requiredTextureCount = 4;
+            AppLog.d(TAG, "使用银河A7配置：横屏4摄像头布局（沿用E5）");
+        }
         // 多视角布局：自定义布局 + 圆角UI + 车辆控制
         else if (appConfig.isMultiviewCarModel()) {
             layoutId = R.layout.activity_main_multiview;
@@ -2700,6 +2707,9 @@ public class MainActivity extends AppCompatActivity {
                 } else if (AppConfig.CAR_MODEL_XINGHAN_7.equals(carModel)) {
                     // 26款星舰7：使用固定映射（前3后2左4右1）
                     initCamerasForXinghan7(cameraIds);
+                } else if (AppConfig.CAR_MODEL_GALAXY_A7.equals(carModel)) {
+                    // 银河A7：沿用银河E5固定映射
+                    initCamerasForGalaxyE5(cameraIds);
                 } else if (appConfig.needsCustomLayoutManager()) {
                     // 自定义车型/多视角：使用用户配置的摄像头映射
                     initCamerasForCustomModel(cameraIds);

--- a/app/src/main/java/com/kooo/evcam/SettingsFragment.java
+++ b/app/src/main/java/com/kooo/evcam/SettingsFragment.java
@@ -85,7 +85,7 @@ public class SettingsFragment extends Fragment {
     // 车型配置相关
     private Spinner carModelSpinner;
     private Button customCameraConfigButton;
-    private static final String[] CAR_MODEL_OPTIONS = {"银河E5", "银河E5-多按钮", "银河L6/L7", "银河L7-多按钮", "26款星舰7", "手机", "自定义车型", "多视角布局"};
+    private static final String[] CAR_MODEL_OPTIONS = {"银河E5", "银河A7", "银河E5-多按钮", "银河L6/L7", "银河L7-多按钮", "26款星舰7", "手机", "自定义车型", "多视角布局"};
     private boolean isInitializingCarModel = false;
     private String lastAppliedCarModel = null;
     
@@ -1149,21 +1149,24 @@ public class SettingsFragment extends Fragment {
                     newModel = AppConfig.CAR_MODEL_GALAXY_E5;
                     modelName = "银河E5";
                 } else if (position == 1) {
+                    newModel = AppConfig.CAR_MODEL_GALAXY_A7;
+                    modelName = "银河A7";
+                } else if (position == 2) {
                     newModel = AppConfig.CAR_MODEL_E5_MULTI;
                     modelName = "银河E5-多按钮";
-                } else if (position == 2) {
+                } else if (position == 3) {
                     newModel = AppConfig.CAR_MODEL_L7;
                     modelName = "银河L6/L7";
-                } else if (position == 3) {
+                } else if (position == 4) {
                     newModel = AppConfig.CAR_MODEL_L7_MULTI;
                     modelName = "银河L7-多按钮";
-                } else if (position == 4) {
+                } else if (position == 5) {
                     newModel = AppConfig.CAR_MODEL_XINGHAN_7;
                     modelName = "26款星舰7";
-                } else if (position == 5) {
+                } else if (position == 6) {
                     newModel = AppConfig.CAR_MODEL_PHONE;
                     modelName = "手机";
-                } else if (position == 7) {
+                } else if (position == 8) {
                     newModel = AppConfig.CAR_MODEL_MULTIVIEW;
                     modelName = "多视角布局";
                 } else {
@@ -1172,7 +1175,7 @@ public class SettingsFragment extends Fragment {
                 }
 
                 // 自定义车型和多视角布局显示配置按钮
-                updateCustomConfigButtonVisibility(position == 6 || position == 7);
+                updateCustomConfigButtonVisibility(position == 7 || position == 8);
 
                 if (isInitializingCarModel) {
                     return;
@@ -1203,20 +1206,22 @@ public class SettingsFragment extends Fragment {
         
         String currentModel = appConfig.getCarModel();
         int selectedIndex = 0;
-        if (AppConfig.CAR_MODEL_E5_MULTI.equals(currentModel)) {
+        if (AppConfig.CAR_MODEL_GALAXY_A7.equals(currentModel)) {
             selectedIndex = 1;
-        } else if (AppConfig.CAR_MODEL_L7.equals(currentModel)) {
+        } else if (AppConfig.CAR_MODEL_E5_MULTI.equals(currentModel)) {
             selectedIndex = 2;
-        } else if (AppConfig.CAR_MODEL_L7_MULTI.equals(currentModel)) {
+        } else if (AppConfig.CAR_MODEL_L7.equals(currentModel)) {
             selectedIndex = 3;
-        } else if (AppConfig.CAR_MODEL_XINGHAN_7.equals(currentModel)) {
+        } else if (AppConfig.CAR_MODEL_L7_MULTI.equals(currentModel)) {
             selectedIndex = 4;
-        } else if (AppConfig.CAR_MODEL_PHONE.equals(currentModel)) {
+        } else if (AppConfig.CAR_MODEL_XINGHAN_7.equals(currentModel)) {
             selectedIndex = 5;
-        } else if (AppConfig.CAR_MODEL_CUSTOM.equals(currentModel)) {
+        } else if (AppConfig.CAR_MODEL_PHONE.equals(currentModel)) {
             selectedIndex = 6;
-        } else if (AppConfig.CAR_MODEL_MULTIVIEW.equals(currentModel)) {
+        } else if (AppConfig.CAR_MODEL_CUSTOM.equals(currentModel)) {
             selectedIndex = 7;
+        } else if (AppConfig.CAR_MODEL_MULTIVIEW.equals(currentModel)) {
+            selectedIndex = 8;
         }
         carModelSpinner.setSelection(selectedIndex);
         

--- a/app/src/main/java/com/kooo/evcam/camera/CameraManagerHolder.java
+++ b/app/src/main/java/com/kooo/evcam/camera/CameraManagerHolder.java
@@ -126,6 +126,9 @@ public class CameraManagerHolder {
             initCamerasForPhone(cameraIds);
         } else if (AppConfig.CAR_MODEL_XINGHAN_7.equals(carModel)) {
             initCamerasForXinghan7(cameraIds);
+        } else if (AppConfig.CAR_MODEL_GALAXY_A7.equals(carModel)) {
+            // 银河A7：沿用银河E5固定映射
+            initCamerasForGalaxyE5(cameraIds);
         } else if (appConfig.isCustomCarModel()) {
             initCamerasForCustomModel(appConfig, cameraIds);
         } else {

--- a/app/src/main/java/com/kooo/evcam/camera/CodecVideoRecorder.java
+++ b/app/src/main/java/com/kooo/evcam/camera/CodecVideoRecorder.java
@@ -843,31 +843,18 @@ public class CodecVideoRecorder {
     private void createEncoder() throws IOException {
         // 检测并选择最优编码格式
         mimeType = selectBestEncoder();
-        
-        // 计算最优码率
-        int optimalBitrate = calculateOptimalBitrate();
-        
-        // 如果启用了补盲优化模式，使用降低的帧率
+
+        // 保持 v1.2.4 兼容路径：使用显式配置值，不附加 Profile/Level，交由系统默认能力协商
         int effectiveFrameRate = blindSpotOptimizeMode ? BLIND_SPOT_OPTIMIZED_FPS : frameRate;
-        
+
         MediaFormat format = MediaFormat.createVideoFormat(mimeType, width, height);
         format.setInteger(MediaFormat.KEY_COLOR_FORMAT, MediaCodecInfo.CodecCapabilities.COLOR_FormatSurface);
-        format.setInteger(MediaFormat.KEY_BIT_RATE, optimalBitrate);
+        format.setInteger(MediaFormat.KEY_BIT_RATE, bitRate);
         format.setInteger(MediaFormat.KEY_FRAME_RATE, effectiveFrameRate);
         format.setInteger(MediaFormat.KEY_I_FRAME_INTERVAL, I_FRAME_INTERVAL);
-        
-        // HEVC 特定优化参数
-        if (mimeType.equals(MIME_TYPE_HEVC)) {
-            // 设置 HEVC 的 Profile 和 Level 以获得更好效率
-            format.setInteger(MediaFormat.KEY_PROFILE, MediaCodecInfo.CodecProfileLevel.HEVCProfileMain);
-            format.setInteger(MediaFormat.KEY_LEVEL, MediaCodecInfo.CodecProfileLevel.HEVCHighTierLevel4);
-        } else {
-            // H.264 优化参数
-            format.setInteger(MediaFormat.KEY_PROFILE, MediaCodecInfo.CodecProfileLevel.AVCProfileHigh);
-        }
 
-        // 优化：使用硬件编码器创建方法
-        encoder = createHardwareEncoder(mimeType);
+        // 兼容性优先：让系统选择可用编码器，避免特定硬件编码器 + Profile 组合导致 configure 失败
+        encoder = MediaCodec.createEncoderByType(mimeType);
         encoder.configure(format, null, null, MediaCodec.CONFIGURE_FLAG_ENCODE);
 
         encoderInputSurface = encoder.createInputSurface();
@@ -875,9 +862,9 @@ public class CodecVideoRecorder {
 
         bufferInfo = new MediaCodec.BufferInfo();
 
-        AppLog.d(TAG, "Camera " + cameraId + " Encoder created: " + width + "x" + height + 
-                " @ " + effectiveFrameRate + "fps" + (blindSpotOptimizeMode ? "(补盲优化)" : "") + 
-                ", " + (optimalBitrate / 1000) + " Kbps, " + 
+        AppLog.d(TAG, "Camera " + cameraId + " Encoder created: " + width + "x" + height +
+                " @ " + effectiveFrameRate + "fps" + (blindSpotOptimizeMode ? "(补盲优化)" : "") +
+                ", " + (bitRate / 1000) + " Kbps, " +
                 (mimeType.equals(MIME_TYPE_HEVC) ? "HEVC" : "H.264"));
     }
 
@@ -887,16 +874,9 @@ public class CodecVideoRecorder {
      * 优化：优先选择硬件编码器，性能更好
      */
     private String selectBestEncoder() {
-        try {
-            // 检查 HEVC 编码器是否可用
-            MediaCodec hevcEncoder = MediaCodec.createEncoderByType(MIME_TYPE_HEVC);
-            hevcEncoder.release();
-            AppLog.d(TAG, "HEVC encoder available, using H.265 for better efficiency");
-            return MIME_TYPE_HEVC;
-        } catch (Exception e) {
-            AppLog.w(TAG, "HEVC encoder not available, falling back to H.264");
-            return MIME_TYPE_H264;
-        }
+        // 回退项 #1：为兼容部分车型，固定使用 H.264，避免 HEVC 在车机硬件上的闪烁问题
+        AppLog.i(TAG, "Camera " + cameraId + " force H.264 encoder for stability");
+        return MIME_TYPE_H264;
     }
     
     /**


### PR DESCRIPTION
- add Galaxy A7 car model preset and map it to E5 layout/camera mapping behavior
- expose Galaxy A7 option in settings and keep selection index mapping consistent
- keep codec path on H.264 and restore conservative MediaCodec configure path for better device compatibility